### PR TITLE
Fixing issue with IGB only allowing localhost URIs

### DIFF
--- a/EveHQ.Core/IGB.vb
+++ b/EveHQ.Core/IGB.vb
@@ -80,7 +80,7 @@ Public Class IGB
     End Property
     Public Sub RunIGB(ByVal worker As BackgroundWorker, ByVal e As DoWorkEventArgs)
         Dim prefixes(0) As String
-        prefixes(0) = "http://localhost:" & HQ.Settings.IgbPort & "/"
+        prefixes(0) = "http://+:" & HQ.Settings.IgbPort & "/"
 
         ' URI prefixes are required,
         If prefixes Is Nothing OrElse prefixes.Length = 0 Then


### PR DESCRIPTION
# [IGB - Ongoing Issue](http://evehq.co/forum/viewtopic.php?f=9&t=138&p=263)

## Browsing to the IGB server of evehq from an external IP address gives a "Bad Request - Invalid Hostname - HTTP Error 400"

The IGB was told to only respond to connections sent to localhost. It therefore does not respond if a user is trying to access their IGB by using their WAN or even LAN IP, or a hostname that ultimately resolves to the PC running EveHQ. This change tells the IGB's [HttpListener](https://msdn.microsoft.com/en-us/library/system.net.httplistener(v=vs.110).aspx) to accept all HTTP requests on the given port. 