### PR TITLE
Prism - Asset Viewer - Prices

### DIFF
--- a/EveHQ.Prism/Controls/PrismAssetsControl.vb
+++ b/EveHQ.Prism/Controls/PrismAssetsControl.vb
@@ -498,7 +498,7 @@ Namespace Controls
             Dim testAsset As Classes.AssetItem
             For Each updatedAsset As Classes.AssetItem In assetsUpdated
                 testAsset = updatedAsset
-                Dim updateTarget As IEnumerable(Of Tuple(Of Node, Classes.AssetItem)) = (From assetNode In _assetNodes Where CLng(assetNode.Key) = testAsset.TypeID And testAsset.RawQuantity > -2 Select assetNode).SelectMany(Function(a) a.Value).Select(Function(n) New Tuple(Of Node, Classes.AssetItem)(n, testAsset)).ToList()
+                Dim updateTarget As IEnumerable(Of Tuple(Of Node, Classes.AssetItem)) = (From assetNode In _assetNodes Where (CLng(assetNode.Key) = testAsset.TypeID Or CLng(assetNode.Key) = testAsset.ItemID) And testAsset.RawQuantity > -2 Select assetNode).SelectMany(Function(a) a.Value).Select(Function(n) New Tuple(Of Node, Classes.AssetItem)(n, testAsset)).ToList()
 
 
                 assetNodesToUpdate.AddRange(updateTarget)


### PR DESCRIPTION
Prices were not shown in the asset viewer any more for all items/ships
which are stored in the hangar at top level.

After this correction the prices seem fine for all my characters.

Thx to EvaRin for the suggest of the new code:

http://evehq.co/forum/viewtopic.php?f=5&t=99&sid=3c7c478366efa68f3a1bda39bd5378e8&start=10#p221