### PR TITLE
Update to Prism BP Calculator

### DIFF
--- a/EveHQ.Core/SkillFunctions.vb
+++ b/EveHQ.Core/SkillFunctions.vb
@@ -52,11 +52,11 @@ Public Class SkillFunctions
     ' Shared variables for repeated usage
     Shared sTimeSpan, eTimeSpan, tTimeSpan As TimeSpan
 
-    Public Shared Function Roman(ByVal dec As Integer) As String
+	Public Shared Function Roman(ByVal dec As Long) As String
 
         Roman = ""
 
-        Dim intVal(12) As Integer
+        Dim intVal(12) As Long
         Dim strVal(12) As String, intLoopCounter As Integer
 
         intVal(0) = 1 : strVal(0) = "I"
@@ -723,7 +723,7 @@ Public Class SkillFunctions
         Return True
     End Function
 
-    Public Shared Function IsSkillTrained(ByVal cPilot As EveHQPilot, ByVal skillName As String, Optional ByVal toLevel As Integer = 0) As Boolean
+	Public Shared Function IsSkillTrained(ByVal cPilot As EveHQPilot, ByVal skillName As String, Optional ByVal toLevel As Long = 0) As Boolean
         If cPilot.PilotSkills.ContainsKey(skillName) Then
             Dim mySkill As EveHQPilotSkill = cPilot.PilotSkills(skillName)
             Dim myLevel As Integer = CInt(mySkill.Level)

--- a/EveHQ.Prism/BPCalc/OwnedBlueprint.vb
+++ b/EveHQ.Prism/BPCalc/OwnedBlueprint.vb
@@ -177,15 +177,15 @@ Namespace BPCalc
             End If
         End Function
 
-        Public Function CalculateProductionTime(ByVal indSkill As Integer, advIndSkill As Integer, ByVal prodImplantBonus As Double, ByVal productionArray As EveData.AssemblyArray, ByVal bpRuns As Integer) As Long
+        Public Function CalculateProductionTime(ByVal indSkill As Integer, advIndSkill As Integer, ByVal prodImplantBonus As Double, ByVal productionArray As EveData.AssemblyArray, ByVal bpRuns As Long) As Long
             Return CalculateBPProductionTime(PELevel, indSkill, advIndSkill, prodImplantBonus, productionArray, bpRuns)
         End Function
 
-        Public Function CalculateProductionTime(ByVal bppeLevel As Integer, ByVal indSkill As Integer, advIndSkill As Integer, ByVal prodImplantBonus As Double, ByVal productionArray As EveData.AssemblyArray, ByVal bpRuns As Integer) As Long
+        Public Function CalculateProductionTime(ByVal bppeLevel As Integer, ByVal indSkill As Integer, advIndSkill As Integer, ByVal prodImplantBonus As Double, ByVal productionArray As EveData.AssemblyArray, ByVal bpRuns As Long) As Long
             Return CalculateBPProductionTime(bppeLevel, indSkill, advIndSkill, prodImplantBonus, productionArray, bpRuns)
         End Function
 
-        Private Function CalculateBPProductionTime(ByVal bppeLevel As Integer, ByVal indSkill As Integer, advIndSkill As Integer, ByVal prodImplantBonus As Double, ByVal productionArray As EveData.AssemblyArray, ByVal bpRuns As Integer) As Long
+        Private Function CalculateBPProductionTime(ByVal bppeLevel As Integer, ByVal indSkill As Integer, advIndSkill As Integer, ByVal prodImplantBonus As Double, ByVal productionArray As EveData.AssemblyArray, ByVal bpRuns As Long) As Long
             prodImplantBonus = 1 - (prodImplantBonus / 100)
             Dim time As Double = ProductionTime * (1 - (0.04 * indSkill)) * (1 - (0.03 * advIndSkill)) * prodImplantBonus
             time = time * (1 - (bppeLevel / 100))

--- a/EveHQ.Prism/Controls/PrismAssetsControl.vb
+++ b/EveHQ.Prism/Controls/PrismAssetsControl.vb
@@ -498,7 +498,7 @@ Namespace Controls
             Dim testAsset As Classes.AssetItem
             For Each updatedAsset As Classes.AssetItem In assetsUpdated
                 testAsset = updatedAsset
-                Dim updateTarget As IEnumerable(Of Tuple(Of Node, Classes.AssetItem)) = (From assetNode In _assetNodes Where CLng(assetNode.Key) = testAsset.TypeID And testAsset.RawQuantity > -2 Select assetNode).SelectMany(Function(a) a.Value).Select(Function(n) New Tuple(Of Node, Classes.AssetItem)(n, testAsset)).ToList()
+                Dim updateTarget As IEnumerable(Of Tuple(Of Node, Classes.AssetItem)) = (From assetNode In _assetNodes Where (CLng(assetNode.Key) = testAsset.TypeID Or CLng(assetNode.Key) = testAsset.ItemID) And testAsset.RawQuantity > -2 Select assetNode).SelectMany(Function(a) a.Value).Select(Function(n) New Tuple(Of Node, Classes.AssetItem)(n, testAsset)).ToList()
 
 
                 assetNodesToUpdate.AddRange(updateTarget)

--- a/EveHQ.Prism/Controls/PrismResources.vb
+++ b/EveHQ.Prism/Controls/PrismResources.vb
@@ -213,9 +213,9 @@ Namespace Controls
                 For Each resource As JobResource In _currentJob.Resources.Values
                     ' This is a resource so add it
                     If resource.TypeCategory <> 16 Or (resource.TypeCategory = 16 And chkShowSkills.Checked = True) Then
-                        Dim perfectRaw As Integer = CInt(resource.PerfectUnits) * _currentJob.Runs
+                        Dim perfectRaw As Long = CInt(resource.PerfectUnits) * _currentJob.Runs
                         Dim waste As Integer = CInt(resource.WasteUnits)
-                        Dim total As Integer = perfectRaw + waste
+                        Dim total As Long = perfectRaw + waste
                         Dim price As Double = resourceCosts(resource.TypeID)
                         Dim value As Double = total * price
                         ' Add a new list view item
@@ -280,9 +280,9 @@ Namespace Controls
                 Next
                 For Each subJob As Job In _currentJob.SubJobs.Values
                     ' This is another production job
-                    Dim perfectRaw As Integer = CInt(subJob.PerfectUnits) * _currentJob.Runs
+                    Dim perfectRaw As Long = CInt(subJob.PerfectUnits) * _currentJob.Runs
                     Dim waste As Integer = CInt(subJob.WasteUnits)
-                    Dim total As Integer = perfectRaw + waste
+                    Dim total As Long = perfectRaw + waste
                     Dim price As Double = jobCosts(subJob.TypeID)
                     Dim value As Double = total * price
                     Dim newRes As New Node(subJob.TypeName)
@@ -417,7 +417,7 @@ Namespace Controls
                 ' This is another production job
                 Dim perfectRaw As Integer = CInt(subJob.PerfectUnits)
                 Dim waste As Integer = CInt(subJob.WasteUnits)
-                Dim runs As Integer = parentJob.Runs
+                Dim runs As Long = parentJob.Runs
                 Dim total As Integer = perfectRaw + waste
                 Dim price As Double = jobCosts(subJob.TypeID)
                 Dim value As Double = total * price

--- a/EveHQ.Prism/Forms/frmBPCalculator.Designer.vb
+++ b/EveHQ.Prism/Forms/frmBPCalculator.Designer.vb
@@ -201,27 +201,35 @@ Namespace Forms
         Me.btnExportToTSV = New DevComponents.DotNetBar.ButtonItem()
         Me.SuperTooltip1 = New DevComponents.DotNetBar.SuperTooltip()
         Me.SaveJobDialogCheckBox = New DevComponents.DotNetBar.Command(Me.components)
-        Me.PanelEx1.SuspendLayout
-        Me.gpPilotSkills.SuspendLayout
-        Me.gpProductionSkills.SuspendLayout
-        Me.gpResearchSkills.SuspendLayout
-        Me.gpBPSelection.SuspendLayout
-        CType(Me.pbBP,System.ComponentModel.ISupportInitialize).BeginInit
-        CType(Me.nudCopyRuns,System.ComponentModel.ISupportInitialize).BeginInit
-        CType(Me.tabBPCalcFunctions,System.ComponentModel.ISupportInitialize).BeginInit
-        Me.tabBPCalcFunctions.SuspendLayout
-        Me.tcpInvention.SuspendLayout
-        CType(Me.adtInventionProfits,System.ComponentModel.ISupportInitialize).BeginInit
-        CType(Me.nudInventionSkill2,System.ComponentModel.ISupportInitialize).BeginInit
-        CType(Me.nudInventionSkill3,System.ComponentModel.ISupportInitialize).BeginInit
-        CType(Me.nudInventionSkill1,System.ComponentModel.ISupportInitialize).BeginInit
-        CType(Me.nudInventionBPCRuns,System.ComponentModel.ISupportInitialize).BeginInit
-        Me.tcpResearch.SuspendLayout
-        Me.tcpProduction.SuspendLayout
-        CType(Me.nudRuns,System.ComponentModel.ISupportInitialize).BeginInit
-        CType(Me.nudTELevel,System.ComponentModel.ISupportInitialize).BeginInit
-        CType(Me.nudMELevel,System.ComponentModel.ISupportInitialize).BeginInit
-        Me.SuspendLayout
+        Me.stnMeBonus = New DevComponents.Editors.IntegerInput()
+        Me.Label1 = New System.Windows.Forms.Label()
+        Me.PACUnitValue = New EveHQ.Prism.Controls.PriceAdjustmentControl()
+        Me.PPRProduction = New EveHQ.Prism.Controls.PrismResources()
+        Me.PPRInvention = New EveHQ.Prism.Controls.PrismResources()
+        Me.PACDecryptor = New EveHQ.Prism.Controls.PriceAdjustmentControl()
+        Me.PACSalesPrice = New EveHQ.Prism.Controls.PriceAdjustmentControl()
+        Me.PanelEx1.SuspendLayout()
+        Me.gpPilotSkills.SuspendLayout()
+        Me.gpProductionSkills.SuspendLayout()
+        Me.gpResearchSkills.SuspendLayout()
+        Me.gpBPSelection.SuspendLayout()
+        CType(Me.pbBP, System.ComponentModel.ISupportInitialize).BeginInit()
+        CType(Me.nudCopyRuns, System.ComponentModel.ISupportInitialize).BeginInit()
+        CType(Me.tabBPCalcFunctions, System.ComponentModel.ISupportInitialize).BeginInit()
+        Me.tabBPCalcFunctions.SuspendLayout()
+        Me.tcpInvention.SuspendLayout()
+        CType(Me.adtInventionProfits, System.ComponentModel.ISupportInitialize).BeginInit()
+        CType(Me.nudInventionSkill2, System.ComponentModel.ISupportInitialize).BeginInit()
+        CType(Me.nudInventionSkill3, System.ComponentModel.ISupportInitialize).BeginInit()
+        CType(Me.nudInventionSkill1, System.ComponentModel.ISupportInitialize).BeginInit()
+        CType(Me.nudInventionBPCRuns, System.ComponentModel.ISupportInitialize).BeginInit()
+        Me.tcpResearch.SuspendLayout()
+        Me.tcpProduction.SuspendLayout()
+        CType(Me.nudRuns, System.ComponentModel.ISupportInitialize).BeginInit()
+        CType(Me.nudTELevel, System.ComponentModel.ISupportInitialize).BeginInit()
+        CType(Me.nudMELevel, System.ComponentModel.ISupportInitialize).BeginInit()
+        CType(Me.stnMeBonus, System.ComponentModel.ISupportInitialize).BeginInit()
+        Me.SuspendLayout()
         '
         'lblBPRuns
         '
@@ -2112,6 +2120,8 @@ Namespace Forms
         '
         'tcpProduction
         '
+        Me.tcpProduction.Controls.Add(Me.stnMeBonus)
+        Me.tcpProduction.Controls.Add(Me.Label1)
         Me.tcpProduction.Controls.Add(Me.lblProfitMarkup)
         Me.tcpProduction.Controls.Add(Me.lblProfitMargin)
         Me.tcpProduction.Controls.Add(Me.lblProfitMarkupLbl)
@@ -2392,6 +2402,87 @@ Namespace Forms
         Me.SaveJobDialogCheckBox.Name = "SaveJobDialogCheckBox"
         Me.SaveJobDialogCheckBox.Text = "Do not show this again"
         '
+        'stnMeBonus
+        '
+        '
+        '
+        '
+        Me.stnMeBonus.BackgroundStyle.Class = "DateTimeInputBackground"
+        Me.stnMeBonus.BackgroundStyle.CornerType = DevComponents.DotNetBar.eCornerType.Square
+        Me.stnMeBonus.ButtonFreeText.Shortcut = DevComponents.DotNetBar.eShortcut.F2
+        Me.stnMeBonus.Location = New System.Drawing.Point(119, 93)
+        Me.stnMeBonus.MaxValue = 20
+        Me.stnMeBonus.MinValue = 0
+        Me.stnMeBonus.Name = "stnMeBonus"
+        Me.stnMeBonus.ShowUpDown = True
+        Me.stnMeBonus.Size = New System.Drawing.Size(93, 21)
+        Me.stnMeBonus.TabIndex = 215
+        '
+        'Label1
+        '
+        Me.Label1.AutoSize = True
+        Me.Label1.BackColor = System.Drawing.Color.Transparent
+        Me.Label1.Location = New System.Drawing.Point(10, 95)
+        Me.Label1.Name = "Label1"
+        Me.Label1.Size = New System.Drawing.Size(94, 13)
+        Me.Label1.TabIndex = 214
+        Me.Label1.Text = "Station ME Bonus:"
+        '
+        'PACUnitValue
+        '
+        Me.PACUnitValue.Location = New System.Drawing.Point(381, 113)
+        Me.PACUnitValue.Name = "PACUnitValue"
+        Me.PACUnitValue.Price = 0.0R
+        Me.PACUnitValue.Size = New System.Drawing.Size(20, 12)
+        Me.PACUnitValue.TabIndex = 209
+        Me.PACUnitValue.TypeID = 0
+        '
+        'PPRProduction
+        '
+        Me.PPRProduction.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
+                        Or System.Windows.Forms.AnchorStyles.Left) _
+                        Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+        Me.PPRProduction.BatchJob = Nothing
+        Me.PPRProduction.Font = New System.Drawing.Font("Tahoma", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.PPRProduction.InventionBP = Nothing
+        Me.PPRProduction.Location = New System.Drawing.Point(0, 163)
+        Me.PPRProduction.Name = "PPRProduction"
+        Me.PPRProduction.ProductionJob = Nothing
+        Me.PPRProduction.Size = New System.Drawing.Size(836, 362)
+        Me.PPRProduction.TabIndex = 0
+        '
+        'PPRInvention
+        '
+        Me.PPRInvention.Anchor = CType((((System.Windows.Forms.AnchorStyles.Top Or System.Windows.Forms.AnchorStyles.Bottom) _
+                        Or System.Windows.Forms.AnchorStyles.Left) _
+                        Or System.Windows.Forms.AnchorStyles.Right), System.Windows.Forms.AnchorStyles)
+        Me.PPRInvention.BatchJob = Nothing
+        Me.PPRInvention.Font = New System.Drawing.Font("Tahoma", 8.25!, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, CType(0, Byte))
+        Me.PPRInvention.InventionBP = Nothing
+        Me.PPRInvention.Location = New System.Drawing.Point(0, 229)
+        Me.PPRInvention.Name = "PPRInvention"
+        Me.PPRInvention.ProductionJob = Nothing
+        Me.PPRInvention.Size = New System.Drawing.Size(833, 296)
+        Me.PPRInvention.TabIndex = 0
+        '
+        'PACDecryptor
+        '
+        Me.PACDecryptor.Location = New System.Drawing.Point(429, 18)
+        Me.PACDecryptor.Name = "PACDecryptor"
+        Me.PACDecryptor.Price = 0.0R
+        Me.PACDecryptor.Size = New System.Drawing.Size(20, 12)
+        Me.PACDecryptor.TabIndex = 209
+        Me.PACDecryptor.TypeID = 0
+        '
+        'PACSalesPrice
+        '
+        Me.PACSalesPrice.Location = New System.Drawing.Point(429, 141)
+        Me.PACSalesPrice.Name = "PACSalesPrice"
+        Me.PACSalesPrice.Price = 0.0R
+        Me.PACSalesPrice.Size = New System.Drawing.Size(20, 12)
+        Me.PACSalesPrice.TabIndex = 208
+        Me.PACSalesPrice.TypeID = 0
+        '
         'FrmBPCalculator
         '
         Me.AutoScaleDimensions = New System.Drawing.SizeF(6!, 13!)
@@ -2407,35 +2498,36 @@ Namespace Forms
         Me.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent
         Me.Text = "Blueprint Calculator"
         Me.TransparencyKey = System.Drawing.Color.LavenderBlush
-        Me.PanelEx1.ResumeLayout(false)
-        Me.PanelEx1.PerformLayout
-        Me.gpPilotSkills.ResumeLayout(false)
-        Me.gpPilotSkills.PerformLayout
-        Me.gpProductionSkills.ResumeLayout(false)
-        Me.gpProductionSkills.PerformLayout
-        Me.gpResearchSkills.ResumeLayout(false)
-        Me.gpResearchSkills.PerformLayout
-        Me.gpBPSelection.ResumeLayout(false)
-        Me.gpBPSelection.PerformLayout
-        CType(Me.pbBP,System.ComponentModel.ISupportInitialize).EndInit
-        CType(Me.nudCopyRuns,System.ComponentModel.ISupportInitialize).EndInit
-        CType(Me.tabBPCalcFunctions,System.ComponentModel.ISupportInitialize).EndInit
-        Me.tabBPCalcFunctions.ResumeLayout(false)
-        Me.tcpInvention.ResumeLayout(false)
-        Me.tcpInvention.PerformLayout
-        CType(Me.adtInventionProfits,System.ComponentModel.ISupportInitialize).EndInit
-        CType(Me.nudInventionSkill2,System.ComponentModel.ISupportInitialize).EndInit
-        CType(Me.nudInventionSkill3,System.ComponentModel.ISupportInitialize).EndInit
-        CType(Me.nudInventionSkill1,System.ComponentModel.ISupportInitialize).EndInit
-        CType(Me.nudInventionBPCRuns,System.ComponentModel.ISupportInitialize).EndInit
-        Me.tcpResearch.ResumeLayout(false)
-        Me.tcpResearch.PerformLayout
-        Me.tcpProduction.ResumeLayout(false)
-        Me.tcpProduction.PerformLayout
-        CType(Me.nudRuns,System.ComponentModel.ISupportInitialize).EndInit
-        CType(Me.nudTELevel,System.ComponentModel.ISupportInitialize).EndInit
-        CType(Me.nudMELevel,System.ComponentModel.ISupportInitialize).EndInit
-        Me.ResumeLayout(false)
+            Me.PanelEx1.ResumeLayout(False)
+            Me.PanelEx1.PerformLayout()
+            Me.gpPilotSkills.ResumeLayout(False)
+            Me.gpPilotSkills.PerformLayout()
+            Me.gpProductionSkills.ResumeLayout(False)
+            Me.gpProductionSkills.PerformLayout()
+            Me.gpResearchSkills.ResumeLayout(False)
+            Me.gpResearchSkills.PerformLayout()
+            Me.gpBPSelection.ResumeLayout(False)
+            Me.gpBPSelection.PerformLayout()
+            CType(Me.pbBP, System.ComponentModel.ISupportInitialize).EndInit()
+            CType(Me.nudCopyRuns, System.ComponentModel.ISupportInitialize).EndInit()
+            CType(Me.tabBPCalcFunctions, System.ComponentModel.ISupportInitialize).EndInit()
+            Me.tabBPCalcFunctions.ResumeLayout(False)
+            Me.tcpInvention.ResumeLayout(False)
+            Me.tcpInvention.PerformLayout()
+            CType(Me.adtInventionProfits, System.ComponentModel.ISupportInitialize).EndInit()
+            CType(Me.nudInventionSkill2, System.ComponentModel.ISupportInitialize).EndInit()
+            CType(Me.nudInventionSkill3, System.ComponentModel.ISupportInitialize).EndInit()
+            CType(Me.nudInventionSkill1, System.ComponentModel.ISupportInitialize).EndInit()
+            CType(Me.nudInventionBPCRuns, System.ComponentModel.ISupportInitialize).EndInit()
+            Me.tcpResearch.ResumeLayout(False)
+            Me.tcpResearch.PerformLayout()
+            Me.tcpProduction.ResumeLayout(False)
+            Me.tcpProduction.PerformLayout()
+            CType(Me.nudRuns, System.ComponentModel.ISupportInitialize).EndInit()
+            CType(Me.nudTELevel, System.ComponentModel.ISupportInitialize).EndInit()
+            CType(Me.nudMELevel, System.ComponentModel.ISupportInitialize).EndInit()
+            CType(Me.stnMeBonus, System.ComponentModel.ISupportInitialize).EndInit()
+            Me.ResumeLayout(False)
 
 End Sub
         Friend WithEvents lblBPMELbl As System.Windows.Forms.Label
@@ -2611,6 +2703,8 @@ End Sub
         Friend WithEvents chkInventionFlag As DevComponents.DotNetBar.Controls.CheckBoxX
         Friend WithEvents PanelEx1 As DevComponents.DotNetBar.PanelEx
         Friend WithEvents SaveJobDialogCheckBox As DevComponents.DotNetBar.Command
+        Friend WithEvents stnMeBonus As DevComponents.Editors.IntegerInput
+        Friend WithEvents Label1 As System.Windows.Forms.Label
 
     End Class
 End NameSpace

--- a/EveHQ.Prism/Forms/frmBPCalculator.vb
+++ b/EveHQ.Prism/Forms/frmBPCalculator.vb
@@ -260,6 +260,9 @@ Namespace Forms
             cboScienceImplant.SelectedIndex = 0
             cboIndustryImplant.SelectedIndex = 0
 
+            ' Set Station ME Bonus
+            stnMeBonus.Value = 0
+
             ' Add the skill levels
             cboResearchSkill.BeginUpdate()
             cboMetallurgySkill.BeginUpdate()
@@ -445,7 +448,9 @@ Namespace Forms
                 End If
             End If
 
-            nudRuns.Value = _currentJob.Runs
+            ' This is a risk, but the Runs property needs to be a long so we can support big runs of capitals.  
+            ' But, for the UI, I doubt we will get into 16^2 runs...
+            nudRuns.Value = CInt(_currentJob.Runs)
 
             PPRProduction.ProductionJob = _currentJob
         End Sub
@@ -1649,6 +1654,15 @@ Namespace Forms
 
 #End Region
 
+        Private Sub stnMeBonus_ValueChanged(sender As Object, e As EventArgs) Handles stnMeBonus.ValueChanged
+            If _startUp = False And _updateBPInfo = True Then
+                _currentJob.StnMeBonus = stnMeBonus.Value
+                PPRProduction.ProductionJob = _currentJob
+                ' Set change flag
+                ProductionChanged = True
+            End If
+
+        End Sub
     End Class
 
     Public Enum BPCalcStartMode


### PR DESCRIPTION
BP Calculator Fix and Enhancement
 * Fixed calculation of ME Bonus for materials on a BP
 * Switched runs variables to a long from an int.  Int was overflowing on larger BPs causing a crash.
 * Added a 'Station ME Bonus' control on BP Calculator screen.  Allows user to factor in ME bonus that some null sec stations provide.